### PR TITLE
Simplify handling for custom cell heights

### DIFF
--- a/InlineDatePicker/VCAddPersonTableViewController.m
+++ b/InlineDatePicker/VCAddPersonTableViewController.m
@@ -81,15 +81,13 @@
 
 -(CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
     
-    CGFloat height = self.tableView.rowHeight;
-    
-    if (indexPath.row == kDatePickerIndex){
-        
-        height = self.datePickerIsShowing ? kDatePickerCellHeight : 0.0f;
+    if (indexPath.row == kDatePickerIndex && self.datePickerIsShowing == NO){
+        //hide date picker
+        return 0.0f;
         
     }
     
-    return height;
+    return [super tableView:tableView heightForRowAtIndexPath:indexPath];
 }
 
 -(void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {


### PR DESCRIPTION
If some of the cells in the static table have a custom height, then it’s a little simpler to let the superclass handle the height for those cells.
